### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -74,6 +74,8 @@ jobs:
   deploy:
     name: Deploy Preview
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: test
     steps:
       - name: Checkout source code


### PR DESCRIPTION
Potential fix for [https://github.com/m-calabresi/speezy/security/code-scanning/3](https://github.com/m-calabresi/speezy/security/code-scanning/3)

To fix this problem, you should explicitly add a `permissions` block to the affected job in your workflow file. The best way to do this is to add `permissions: contents: read` at the job-level for the `deploy` job. You should add it under the `runs-on:` line as per the recommended format. This will restrict GITHUB_TOKEN to read-only access to repository contents, following the principle of least privilege. You do not need to change imports or add any new code - only a yaml change in the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
