### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,6 +40,8 @@ on:
 jobs:
   test:
     name: Test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/m-calabresi/speezy/security/code-scanning/2](https://github.com/m-calabresi/speezy/security/code-scanning/2)

To fix the issue, the workflow should explicitly set the minimum required permissions for the `test` job so that the `GITHUB_TOKEN` permissions are limited. Since this job does not push, merge, create issues, releases, or interact with repo content in write mode, we can restrict it to `contents: read` to follow least privilege. Edit the `.github/workflows/preview.yml` file, adding the `permissions:` block with `contents: read` under the `test` job (line 42, just below `name: Test` and above `runs-on:`).

No additional methods, imports, or definitions are needed, just a yaml edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
