### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     name: Test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/m-calabresi/speezy/security/code-scanning/1](https://github.com/m-calabresi/speezy/security/code-scanning/1)

To address the problem, add an explicit `permissions:` block under the `test` job in `.github/workflows/release.yml`. Since the job only appears to need read access (not writing code, releases, or packages), set it to the minimal `contents: read`. This change should occur immediately after the `name: Test` line (i.e., after line 10, before `runs-on:`). No imports, definitions, or method changes are required; it's a configuration edit only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
