### PR TITLE
feat(form): implement new transaction form with validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
     - [x] Make repo public
 - Bugs
     - [x] Fix layout shift on mobile for navbar (on scroll & on account modal open)
+    - [ ] Decide whether to fix navbar showing on top of keyboard when scrolling all the way down from an input text (is it really a bug?)
 
 ## Commit SemVer
 

--- a/actions/transactions.ts
+++ b/actions/transactions.ts
@@ -1,5 +1,6 @@
-import sql from "@/lib/db";
 import type { RawTransaction, Transaction } from "@/types/transaction";
+
+import sql from "@/lib/db";
 
 export async function getTransactions() {
     const transactions = await sql<RawTransaction[]>`

--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -1,9 +1,10 @@
-import { Button } from "@/components/ui/button";
-import LogoDark from "@/public/logo.svg";
 import { AlertCircleIcon, BugIcon, CloudLightningIcon, LogInIcon, ShieldIcon } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import LogoDark from "@/public/logo.svg";
 
 export const metadata: Metadata = {
     title: "Auth Error - speezy",

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,13 +1,14 @@
-import { auth } from "@/auth";
-import { SignInButton } from "@/components/auth/buttons";
-import { UserAvatar } from "@/components/user-avatar";
-import { cn } from "@/lib/utils";
-import LogoDark from "@/public/logo.svg";
 import { ArrowRightIcon, ShieldAlertIcon, ShieldIcon, UserIcon } from "lucide-react";
 import type { Metadata } from "next";
 import type { User } from "next-auth";
 import Image from "next/image";
 import { redirect } from "next/navigation";
+
+import { auth } from "@/auth";
+import { SignInButton } from "@/components/auth/buttons";
+import { UserAvatar } from "@/components/user-avatar";
+import { cn } from "@/lib/utils";
+import LogoDark from "@/public/logo.svg";
 
 export const metadata: Metadata = {
     title: "Sign In - speezy",

--- a/app/auth/unauthorized/page.tsx
+++ b/app/auth/unauthorized/page.tsx
@@ -1,9 +1,10 @@
-import { Button } from "@/components/ui/button";
-import LogoDark from "@/public/logo.svg";
 import { AlertTriangleIcon, ArrowLeftIcon, LockIcon, LogInIcon, ShieldIcon, ShieldXIcon } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import LogoDark from "@/public/logo.svg";
 
 export const metadata: Metadata = {
     title: "Unauthorized - speezy",

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,6 +19,30 @@
     }
 }
 
+@custom-variant first-two-children {
+    & > *:nth-child(-n + 2) {
+        @slot;
+    }
+}
+
+@custom-variant last-two-children {
+    & > *:nth-last-child(-n + 2) {
+        @slot;
+    }
+}
+
+@custom-variant first-two {
+    &:nth-child(-n + 2) {
+        @slot;
+    }
+}
+
+@custom-variant last-two {
+    &:nth-last-child(-n + 2) {
+        @slot;
+    }
+}
+
 @theme inline {
     --font-poppins: var(--font-poppins-sans);
     --font-bricolage-grotesque: var(--font-bricolage-grotesque-serif);

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,3 +1,6 @@
+import { CalendarIcon, CreditCardIcon } from "lucide-react";
+import type { Metadata } from "next";
+
 import { getTransactions } from "@/actions/transactions";
 import ReleaseInfo from "@/components/release-info";
 import { Badge } from "@/components/ui/badge";
@@ -5,8 +8,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { cn, formatCurrency, formatDate } from "@/lib/utils";
 import { PageProvider } from "@/providers/page-provider";
 import type { Transaction } from "@/types/transaction";
-import { CalendarIcon, CreditCardIcon } from "lucide-react";
-import type { Metadata } from "next";
 
 export const metadata: Metadata = {
     title: "Stats - speezy",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
-import { ThemeProvider } from "@/providers/theme-provider";
 import type { Metadata } from "next";
 import { Bricolage_Grotesque, Poppins } from "next/font/google";
+
+import { ThemeProvider } from "@/providers/theme-provider";
 import "./globals.css";
 
 const poppins = Poppins({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Bricolage_Grotesque, Poppins } from "next/font/google";
 
+import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/providers/theme-provider";
 import "./globals.css";
 
@@ -47,6 +48,12 @@ export default function RootLayout({
                     enableSystem
                     disableTransitionOnChange>
                     <div className="from-background to-primary/40 scrollbar-hidden flex h-full w-full flex-col overflow-auto bg-gradient-to-br">{children}</div>
+                    <Toaster
+                        richColors
+                        closeButton={false}
+                        expand={false}
+                        position="bottom-center"
+                    />
                 </ThemeProvider>
             </body>
         </html>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,9 +1,10 @@
-import { Button } from "@/components/ui/button";
-import LogoDark from "@/public/logo.svg";
 import { CompassIcon, HelpCircleIcon, HouseIcon, LogInIcon, MapPinIcon, SearchIcon, ShieldIcon } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import LogoDark from "@/public/logo.svg";
 
 export const metadata: Metadata = {
     title: "Not Found - speezy",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
+import type { Metadata } from "next";
+
 import { NewTransactionForm } from "@/components/new-transaction-form";
 import { PageProvider } from "@/providers/page-provider";
-import type { Metadata } from "next";
 
 export const metadata: Metadata = {
     title: "New entry - speezy",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
-import ComingSoon from "@/components/coming-soon";
-import ReleaseInfo from "@/components/release-info";
+import { NewTransactionForm } from "@/components/new-transaction-form";
 import { PageProvider } from "@/providers/page-provider";
 import type { Metadata } from "next";
 
@@ -12,8 +11,7 @@ export const metadata: Metadata = {
 export default function Home() {
     return (
         <PageProvider path="/">
-            <ComingSoon />
-            <ReleaseInfo />
+            <NewTransactionForm />
         </PageProvider>
     );
 }

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,7 +1,8 @@
+import type { Metadata } from "next";
+
 import ComingSoon from "@/components/coming-soon";
 import ReleaseInfo from "@/components/release-info";
 import { PageProvider } from "@/providers/page-provider";
-import type { Metadata } from "next";
 
 export const metadata: Metadata = {
     title: "Stats - speezy",

--- a/auth.ts
+++ b/auth.ts
@@ -49,8 +49,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
                             "Content-Type": "application/x-www-form-urlencoded",
                         },
                         body: new URLSearchParams({
-                            client_id: process.env.AUTH_KEYCLOAK_ID!,
-                            client_secret: process.env.AUTH_KEYCLOAK_SECRET!,
+                            client_id: process.env.AUTH_KEYCLOAK_CLIENT_ID!,
+                            client_secret: process.env.AUTH_KEYCLOAK_CLIENT_SECRET!,
                             grant_type: "refresh_token",
                             refresh_token: token.refresh_token as string,
                         }),

--- a/auth.ts
+++ b/auth.ts
@@ -1,6 +1,7 @@
-import { getRoles } from "@/lib/auth";
 import NextAuth from "next-auth";
 import Keycloak from "next-auth/providers/keycloak";
+
+import { getRoles } from "@/lib/auth";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
     providers: [

--- a/components/auth/buttons.tsx
+++ b/components/auth/buttons.tsx
@@ -1,6 +1,7 @@
+import type React from "react";
+
 import { signIn, signOut } from "@/auth";
 import { Button } from "@/components/ui/button";
-import type React from "react";
 
 export async function SignInButton({ callbackUrl, className, children, ...props }: React.ComponentProps<typeof Button> & { callbackUrl?: string }) {
     return (

--- a/components/coming-soon.tsx
+++ b/components/coming-soon.tsx
@@ -1,7 +1,8 @@
+import Image from "next/image";
+
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import PlaceholderImageDark from "@/public/placeholder-dark.svg";
 import PlaceholderImageLight from "@/public/placeholder-light.svg";
-import Image from "next/image";
 
 export default function ComingSoon() {
     return (

--- a/components/modals/about.tsx
+++ b/components/modals/about.tsx
@@ -1,7 +1,8 @@
+import Link from "next/link";
+
 import { Button } from "@/components/ui/button";
 import { Modal, ModalBody, ModalBodyOption, ModalBodyOptionGroup, ModalContent, ModalFooter, ModalHeader, ModalTitle, ModalTrigger } from "@/components/ui/modal";
 import { buildNumber } from "@/lib/release";
-import Link from "next/link";
 
 export function AboutModal() {
     return (

--- a/components/modals/profile.tsx
+++ b/components/modals/profile.tsx
@@ -1,3 +1,7 @@
+import { LogOutIcon } from "lucide-react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
 import { auth } from "@/auth";
 import { SignOutButton } from "@/components/auth/buttons";
 import { AboutModal } from "@/components/modals/about";
@@ -5,9 +9,6 @@ import { ThemeToggleModal } from "@/components/modals/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { Modal, ModalBody, ModalBodyOption, ModalBodyOptionGroup, ModalClose, ModalContent, ModalFooter, ModalHeader, ModalTitle, ModalTrigger } from "@/components/ui/modal";
 import { UserAvatar } from "@/components/user-avatar";
-import { LogOutIcon } from "lucide-react";
-import Link from "next/link";
-import { redirect } from "next/navigation";
 
 export default async function Profile() {
     const session = await auth();

--- a/components/modals/theme-toggle.tsx
+++ b/components/modals/theme-toggle.tsx
@@ -2,10 +2,10 @@
 
 import { MoonIcon, PaintbrushVerticalIcon, SmartphoneIcon, SunIcon } from "lucide-react";
 import { useTheme } from "next-themes";
+import type React from "react";
 
 import { Button } from "@/components/ui/button";
 import { Modal, ModalBody, ModalBodyOption, ModalBodyOptionGroup, ModalClose, ModalContent, ModalHeader, ModalTitle, ModalTrigger } from "@/components/ui/modal";
-import type React from "react";
 
 const themes = [
     { name: "light", Icon: SunIcon },

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,6 +1,7 @@
-import { cn } from "@/lib/utils";
 import { ChartPie, History, Plus } from "lucide-react";
 import Link from "next/link";
+
+import { cn } from "@/lib/utils";
 
 const navItems = [
     { id: "add", url: "/", label: "Add", Icon: Plus },

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { CalendarIcon, EuroIcon, HandCoinsIcon, ShoppingBagIcon } from "lucide-react";
+import { CalendarIcon, EuroIcon, HandCoinsIcon, PlusIcon, ShoppingBagIcon } from "lucide-react";
 import type React from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -221,7 +221,12 @@ export function NewTransactionForm() {
                         </FormItem>
                     )}
                 />
-                <Button type="submit">Submit</Button>
+                <Button
+                    type="submit"
+                    className="h-14 w-full">
+                    <PlusIcon />
+                    Add
+                </Button>
             </form>
         </Form>
     );

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -7,9 +7,10 @@ import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
 import { cn, formatCurrency, formatDate } from "@/lib/utils";
 
 const FormSchema = z.object({
@@ -27,6 +28,7 @@ const FormSchema = z.object({
             error: "Inserisci un importo valido e positivo.",
         },
     ),
+    description: z.string().min(1, { error: "Inserisci una descrizione." }).max(1000, { error: "La descrizione non deve superare i 100 caratteri." }),
 });
 
 export function NewTransactionForm() {
@@ -35,6 +37,7 @@ export function NewTransactionForm() {
         defaultValues: {
             transactionDate: new Date(),
             amount: "",
+            description: "",
         },
     });
 
@@ -132,6 +135,24 @@ export function NewTransactionForm() {
                                 </div>
                             </FormControl>
 
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={form.control}
+                    name="description"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Descrizione</FormLabel>
+                            <FormControl>
+                                <Textarea
+                                    placeholder="Descrivi la transazione"
+                                    className="resize-none"
+                                    {...field}
+                                />
+                            </FormControl>
+                            <FormDescription>{field.value.length}/100 caratteri</FormDescription>
                             <FormMessage />
                         </FormItem>
                     )}

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -31,13 +31,13 @@ const expenseOptions: ExpenseOptionType[] = [
         Icon: EuroIcon,
     },
     {
-        type: "lent",
+        type: "lendPending",
         name: "Prestito",
         description: "Ho prestato denaro, mi deve ritornare.",
         Icon: HandCoinsIcon,
     },
     {
-        type: "borrowed",
+        type: "borrowPending",
         name: "Debito",
         description: "Ho chiesto un prestito, devo restituire denaro.",
         Icon: HandCoinsFlippedIcon,

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -118,16 +118,10 @@ export function NewTransactionForm() {
                                         type="text"
                                         className="w-[240px] ps-9"
                                         onInput={(e) => handleInput(e, onChange)}
-                                        onChange={(e) => {
-                                            const num = e.target.value;
-                                            console.log("onChange", { num });
-
-                                            onChange(num);
-                                        }}
+                                        onChange={onChange}
                                         onBlur={(e) => {
                                             const raw = parseFloat(e.target.value.replace(/[^0-9,]/g, "").replace(",", "."));
                                             const formatted = isNaN(raw) ? "" : formatCurrency(raw, false, false);
-                                            console.log("onBlur", { raw, formatted });
 
                                             onChange(formatted);
                                             onBlur();

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -121,7 +121,7 @@ export function NewTransactionForm() {
                                     <FormControl>
                                         <Button
                                             variant={"outline"}
-                                            className={cn("w-[240px] items-center justify-start pl-3 text-left font-normal")}>
+                                            className={cn("w-full items-center justify-start pl-3 text-left font-normal")}>
                                             <CalendarIcon className="text-muted-foreground h-4 w-4" />
                                             {field.value ? formatDate(field.value, false) : <span>Pick a date</span>}
                                         </Button>
@@ -154,7 +154,7 @@ export function NewTransactionForm() {
                                         step="0.01"
                                         inputMode="decimal"
                                         type="text"
-                                        className="w-[240px] ps-9"
+                                        className="w-full ps-9"
                                         onInput={(e) => handleInput(e, onChange)}
                                         onChange={onChange}
                                         onBlur={(e) => {

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { CalendarIcon, EuroIcon, HandCoinsIcon, PlusIcon, ShoppingBagIcon } from "lucide-react";
 import type React from "react";
 import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
@@ -14,7 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { cn, formatCurrency, formatDate } from "@/lib/utils";
+import { cn, formatCurrency, formatDate, formatExpense } from "@/lib/utils";
 import { expenseOptionTypes, type ExpenseOption } from "@/types/expenses";
 
 const expenseOptions: ExpenseOption[] = [
@@ -76,6 +77,7 @@ export function NewTransactionForm() {
 
     function onSubmit(raw: z.infer<typeof FormSchema>) {
         form.reset();
+        toast.success(`${formatExpense(raw.type)}!`);
 
         const data = {
             ...raw,

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -1,17 +1,48 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { CalendarIcon, EuroIcon } from "lucide-react";
+import { CalendarIcon, EuroIcon, HandCoinsIcon, ShoppingBagIcon } from "lucide-react";
+import type React from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { HandCoinsFlippedIcon } from "@/components/ui/icons";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn, formatCurrency, formatDate } from "@/lib/utils";
+import { expenseOptionTypes, type ExpenseOptionType } from "@/types/expenses";
+
+const expenseOptions: ExpenseOptionType[] = [
+    {
+        type: "expense",
+        name: "Spesa",
+        description: "Ho speso denaro.",
+        Icon: ShoppingBagIcon,
+    },
+    {
+        type: "earning",
+        name: "Entrata",
+        description: "Ho ricevuto denaro.",
+        Icon: EuroIcon,
+    },
+    {
+        type: "lent",
+        name: "Prestito",
+        description: "Ho prestato denaro, mi deve ritornare.",
+        Icon: HandCoinsIcon,
+    },
+    {
+        type: "borrowed",
+        name: "Debito",
+        description: "Ho chiesto un prestito, devo restituire denaro.",
+        Icon: HandCoinsFlippedIcon,
+    },
+];
 
 const FormSchema = z.object({
     transactionDate: z.date({
@@ -29,6 +60,7 @@ const FormSchema = z.object({
         },
     ),
     description: z.string().min(1, { error: "Inserisci una descrizione." }).max(1000, { error: "La descrizione non deve superare i 100 caratteri." }),
+    type: z.enum(expenseOptionTypes, { error: "Seleziona un tipo di transazione valido" }),
 });
 
 export function NewTransactionForm() {
@@ -38,6 +70,7 @@ export function NewTransactionForm() {
             transactionDate: new Date(),
             amount: "",
             description: "",
+            type: "expense",
         },
     });
 
@@ -153,6 +186,35 @@ export function NewTransactionForm() {
                                 />
                             </FormControl>
                             <FormDescription>{field.value.length}/100 caratteri</FormDescription>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={form.control}
+                    name="type"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Tipo</FormLabel>
+                            <FormControl>
+                                <ToggleGroup
+                                    type="single"
+                                    onValueChange={field.onChange}
+                                    {...field}
+                                    className="grid w-full grid-cols-2 gap-4">
+                                    {expenseOptions.map(({ type, name, description, Icon }) => (
+                                        <ToggleGroupItem
+                                            defaultChecked={type === "expense"}
+                                            key={type}
+                                            value={type}
+                                            className="last-two:h-30 last-two:[&>svg]:size-4 last-two:[&>svg]:text-muted-foreground/50 last-two:[&>p]:text-muted-foreground/50 last-two:[&>h3]:mt-0 last-two:text-sm last-two:[&>h3]:text-muted-foreground/70 last-two:justify-start h-50 flex-col items-center justify-center rounded border p-2 text-lg">
+                                            <Icon className="text-muted-foreground size-8" />
+                                            <h3 className="text-foreground mt-2 font-semibold">{name}</h3>
+                                            <p className="text-muted-foreground -mt-3 text-sm font-light text-wrap">{description}</p>
+                                        </ToggleGroupItem>
+                                    ))}
+                                </ToggleGroup>
+                            </FormControl>
                             <FormMessage />
                         </FormItem>
                     )}

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -75,6 +75,8 @@ export function NewTransactionForm() {
     });
 
     function onSubmit(raw: z.infer<typeof FormSchema>) {
+        form.reset();
+
         const data = {
             ...raw,
             transactionDate: raw.transactionDate.toISOString().split("T")[0],

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -1,20 +1,32 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { CalendarIcon } from "lucide-react";
+import { CalendarIcon, EuroIcon } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { cn, formatDate } from "@/lib/utils";
+import { cn, formatCurrency, formatDate } from "@/lib/utils";
 
 const FormSchema = z.object({
     transactionDate: z.date({
         error: "Seleziona la data della transazione.",
     }),
+    amount: z.string().refine(
+        (val: string) => {
+            const normalized = val.replace(".", "").replace(",", ".");
+            const parsed = parseFloat(normalized);
+
+            return !isNaN(parsed) && parsed >= 0;
+        },
+        {
+            error: "Inserisci un importo valido e positivo.",
+        },
+    ),
 });
 
 export function NewTransactionForm() {
@@ -22,12 +34,38 @@ export function NewTransactionForm() {
         resolver: zodResolver(FormSchema, undefined, { raw: true }),
         defaultValues: {
             transactionDate: new Date(),
+            amount: "",
         },
     });
 
     function onSubmit(raw: z.infer<typeof FormSchema>) {
-        console.log({ raw }); // TODO: submit transaction
+        const data = {
+            ...raw,
+            amount: parseFloat(raw.amount.replace(".", "").replace(",", ".")),
+        };
+        console.log({ raw, validated: data }); // TODO: submit transaction
     }
+
+    const handleInput = (e: React.FormEvent<HTMLInputElement>, onChange: (...event: any[]) => void) => {
+        const input = e.target as HTMLInputElement;
+        const value = input.value;
+
+        // Remove any invalid characters (keep only digits and comma)
+        const cleaned = value.replace(/[^0-9,]/g, "");
+
+        // Ensure only one comma
+        const parts = cleaned.split(",");
+        let result = parts[0];
+        if (parts.length > 1) {
+            result += "," + parts[1].substring(0, 2); // Max 2 decimal places
+        }
+
+        if (result !== value) {
+            input.value = result;
+            // Trigger form update
+            onChange(result);
+        }
+    };
 
     return (
         <Form {...form}>
@@ -61,6 +99,45 @@ export function NewTransactionForm() {
                                     />
                                 </PopoverContent>
                             </Popover>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={form.control}
+                    name="amount"
+                    render={({ field: { onChange, onBlur, ...field } }) => (
+                        <FormItem>
+                            <FormLabel>Amount</FormLabel>
+                            <FormControl>
+                                <div className="relative">
+                                    <Input
+                                        placeholder="0.00"
+                                        step="0.01"
+                                        inputMode="decimal"
+                                        type="text"
+                                        className="w-[240px] ps-9"
+                                        onInput={(e) => handleInput(e, onChange)}
+                                        onChange={(e) => {
+                                            const num = e.target.value;
+                                            console.log("onChange", { num });
+
+                                            onChange(num);
+                                        }}
+                                        onBlur={(e) => {
+                                            const raw = parseFloat(e.target.value.replace(/[^0-9,]/g, "").replace(",", "."));
+                                            const formatted = isNaN(raw) ? "" : formatCurrency(raw, false, false);
+                                            console.log("onBlur", { raw, formatted });
+
+                                            onChange(formatted);
+                                            onBlur();
+                                        }}
+                                        {...field}
+                                    />
+                                    <EuroIcon className="text-muted-foreground absolute start-0 top-1/2 ms-3 h-4 w-4 -translate-y-1/2" />
+                                </div>
+                            </FormControl>
+
                             <FormMessage />
                         </FormItem>
                     )}

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -79,6 +79,7 @@ export function NewTransactionForm() {
             ...raw,
             transactionDate: raw.transactionDate.toISOString().split("T")[0],
             amount: parseFloat(raw.amount.replace(".", "").replace(",", ".")),
+            description: raw.description.trim(),
         };
         console.log(data); // TODO: submit transaction
     }

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -204,13 +204,15 @@ export function NewTransactionForm() {
                             <FormLabel>Tipo</FormLabel>
                             <FormControl>
                                 <ToggleGroup
-                                    type="single"
-                                    onValueChange={field.onChange}
                                     {...field}
+                                    type="single"
+                                    value={field.value}
+                                    onValueChange={(val) => {
+                                        if (val) field.onChange(val); // prevent unselect
+                                    }}
                                     className="grid w-full grid-cols-2 gap-4">
                                     {expenseOptions.map(({ type, name, description, Icon }) => (
                                         <ToggleGroupItem
-                                            defaultChecked={type === "expense"}
                                             key={type}
                                             value={type}
                                             className="last-two:h-30 last-two:[&>svg]:size-4 last-two:[&>svg]:text-muted-foreground/50 last-two:[&>p]:text-muted-foreground/50 last-two:[&>h3]:mt-0 last-two:text-sm last-two:[&>h3]:text-muted-foreground/70 last-two:justify-start h-50 flex-col items-center justify-center rounded border p-2 text-lg">

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -183,6 +183,7 @@ export function NewTransactionForm() {
                                 <Textarea
                                     placeholder="Descrivi la transazione"
                                     className="resize-none"
+                                    maxLength={100}
                                     {...field}
                                 />
                             </FormControl>

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -47,7 +47,7 @@ export function NewTransactionForm() {
             transactionDate: raw.transactionDate.toISOString().split("T")[0],
             amount: parseFloat(raw.amount.replace(".", "").replace(",", ".")),
         };
-        console.log({ raw, validated: data }); // TODO: submit transaction
+        console.log(data); // TODO: submit transaction
     }
 
     const handleInput = (e: React.FormEvent<HTMLInputElement>, onChange: (...event: any[]) => void) => {
@@ -135,7 +135,6 @@ export function NewTransactionForm() {
                                     <EuroIcon className="text-muted-foreground absolute start-0 top-1/2 ms-3 h-4 w-4 -translate-y-1/2" />
                                 </div>
                             </FormControl>
-
                             <FormMessage />
                         </FormItem>
                     )}

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -15,9 +15,9 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn, formatCurrency, formatDate } from "@/lib/utils";
-import { expenseOptionTypes, type ExpenseOptionType } from "@/types/expenses";
+import { expenseOptionTypes, type ExpenseOption } from "@/types/expenses";
 
-const expenseOptions: ExpenseOptionType[] = [
+const expenseOptions: ExpenseOption[] = [
     {
         type: "expense",
         name: "Spesa",

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CalendarIcon } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn, formatDate } from "@/lib/utils";
+
+const FormSchema = z.object({
+    transactionDate: z.date({
+        error: "Seleziona la data della transazione.",
+    }),
+});
+
+export function NewTransactionForm() {
+    const form = useForm<z.infer<typeof FormSchema>>({
+        resolver: zodResolver(FormSchema, undefined, { raw: true }),
+        defaultValues: {
+            transactionDate: new Date(),
+        },
+    });
+
+    function onSubmit(raw: z.infer<typeof FormSchema>) {
+        console.log({ raw }); // TODO: submit transaction
+    }
+
+    return (
+        <Form {...form}>
+            <form
+                onSubmit={form.handleSubmit(onSubmit)}
+                className="space-y-8">
+                <FormField
+                    control={form.control}
+                    name="transactionDate"
+                    render={({ field }) => (
+                        <FormItem className="flex flex-col">
+                            <FormLabel>Date</FormLabel>
+                            <Popover>
+                                <PopoverTrigger asChild>
+                                    <FormControl>
+                                        <Button
+                                            variant={"outline"}
+                                            className={cn("w-[240px] items-center justify-start pl-3 text-left font-normal")}>
+                                            <CalendarIcon className="text-muted-foreground h-4 w-4" />
+                                            {field.value ? formatDate(field.value, false) : <span>Pick a date</span>}
+                                        </Button>
+                                    </FormControl>
+                                </PopoverTrigger>
+                                <PopoverContent
+                                    className="w-auto p-0"
+                                    align="start">
+                                    <Calendar
+                                        mode="single"
+                                        selected={field.value}
+                                        onSelect={field.onChange}
+                                    />
+                                </PopoverContent>
+                            </Popover>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <Button type="submit">Submit</Button>
+            </form>
+        </Form>
+    );
+}

--- a/components/new-transaction-form.tsx
+++ b/components/new-transaction-form.tsx
@@ -44,6 +44,7 @@ export function NewTransactionForm() {
     function onSubmit(raw: z.infer<typeof FormSchema>) {
         const data = {
             ...raw,
+            transactionDate: raw.transactionDate.toISOString().split("T")[0],
             amount: parseFloat(raw.amount.replace(".", "").replace(",", ".")),
         };
         console.log({ raw, validated: data }); // TODO: submit transaction

--- a/components/release-info.tsx
+++ b/components/release-info.tsx
@@ -1,10 +1,11 @@
 "server only";
 
+import type React from "react";
+
 import { buildNumber } from "@/lib/release";
 import { cn } from "@/lib/utils";
-import type { HTMLAttributes } from "react";
 
-export default function ReleaseInfo({ className, ...props }: HTMLAttributes<HTMLSpanElement>) {
+export default function ReleaseInfo({ className, ...props }: React.ComponentProps<"h4">) {
     return (
         <h4
             className={cn("bg-primary text-primary-foreground rounded-md px-2 py-1 text-sm leading-none", className)}

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import * as React from "react";
+import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker";
+
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function Calendar({
+    className,
+    classNames,
+    showOutsideDays = true,
+    captionLayout = "label",
+    buttonVariant = "ghost",
+    formatters,
+    components,
+    ...props
+}: React.ComponentProps<typeof DayPicker> & {
+    buttonVariant?: React.ComponentProps<typeof Button>["variant"];
+}) {
+    const defaultClassNames = getDefaultClassNames();
+
+    return (
+        <DayPicker
+            showOutsideDays={showOutsideDays}
+            className={cn(
+                "bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+                String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+                String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+                className,
+            )}
+            captionLayout={captionLayout}
+            formatters={{
+                formatMonthDropdown: (date) => date.toLocaleString("default", { month: "short" }),
+                ...formatters,
+            }}
+            classNames={{
+                root: cn("w-fit", defaultClassNames.root),
+                months: cn("flex gap-4 flex-col md:flex-row relative", defaultClassNames.months),
+                month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
+                nav: cn("flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between", defaultClassNames.nav),
+                button_previous: cn(buttonVariants({ variant: buttonVariant }), "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none", defaultClassNames.button_previous),
+                button_next: cn(buttonVariants({ variant: buttonVariant }), "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none", defaultClassNames.button_next),
+                month_caption: cn("flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)", defaultClassNames.month_caption),
+                dropdowns: cn("w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5", defaultClassNames.dropdowns),
+                dropdown_root: cn("relative has-focus:border-ring border border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] rounded-md", defaultClassNames.dropdown_root),
+                dropdown: cn("absolute bg-popover inset-0 opacity-0", defaultClassNames.dropdown),
+                caption_label: cn(
+                    "select-none font-medium",
+                    captionLayout === "label" ? "text-sm" : "rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5",
+                    defaultClassNames.caption_label,
+                ),
+                table: "w-full border-collapse",
+                weekdays: cn("flex", defaultClassNames.weekdays),
+                weekday: cn("text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none", defaultClassNames.weekday),
+                week: cn("flex w-full mt-2", defaultClassNames.week),
+                week_number_header: cn("select-none w-(--cell-size)", defaultClassNames.week_number_header),
+                week_number: cn("text-[0.8rem] select-none text-muted-foreground", defaultClassNames.week_number),
+                day: cn(
+                    "relative w-full h-full p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none",
+                    defaultClassNames.day,
+                ),
+                range_start: cn("rounded-l-md bg-accent", defaultClassNames.range_start),
+                range_middle: cn("rounded-none", defaultClassNames.range_middle),
+                range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
+                today: cn("bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none", defaultClassNames.today),
+                outside: cn("text-muted-foreground aria-selected:text-muted-foreground", defaultClassNames.outside),
+                disabled: cn("text-muted-foreground opacity-50", defaultClassNames.disabled),
+                hidden: cn("invisible", defaultClassNames.hidden),
+                ...classNames,
+            }}
+            components={{
+                Root: ({ className, rootRef, ...props }) => {
+                    return (
+                        <div
+                            data-slot="calendar"
+                            ref={rootRef}
+                            className={cn(className)}
+                            {...props}
+                        />
+                    );
+                },
+                Chevron: ({ className, orientation, ...props }) => {
+                    if (orientation === "left") {
+                        return (
+                            <ChevronLeftIcon
+                                className={cn("size-4", className)}
+                                {...props}
+                            />
+                        );
+                    }
+
+                    if (orientation === "right") {
+                        return (
+                            <ChevronRightIcon
+                                className={cn("size-4", className)}
+                                {...props}
+                            />
+                        );
+                    }
+
+                    return (
+                        <ChevronDownIcon
+                            className={cn("size-4", className)}
+                            {...props}
+                        />
+                    );
+                },
+                DayButton: CalendarDayButton,
+                WeekNumber: ({ children, ...props }) => {
+                    return (
+                        <td {...props}>
+                            <div className="flex size-(--cell-size) items-center justify-center text-center">{children}</div>
+                        </td>
+                    );
+                },
+                ...components,
+            }}
+            {...props}
+        />
+    );
+}
+
+function CalendarDayButton({ className, day, modifiers, ...props }: React.ComponentProps<typeof DayButton>) {
+    const defaultClassNames = getDefaultClassNames();
+
+    const ref = React.useRef<HTMLButtonElement>(null);
+    React.useEffect(() => {
+        if (modifiers.focused) ref.current?.focus();
+    }, [modifiers.focused]);
+
+    return (
+        <Button
+            ref={ref}
+            variant="ghost"
+            size="icon"
+            data-day={day.date.toLocaleDateString()}
+            data-selected-single={modifiers.selected && !modifiers.range_start && !modifiers.range_end && !modifiers.range_middle}
+            data-range-start={modifiers.range_start}
+            data-range-end={modifiers.range_end}
+            data-range-middle={modifiers.range_middle}
+            className={cn(
+                "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70",
+                defaultClassNames.day,
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+export { Calendar, CalendarDayButton };

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { Controller, FormProvider, useFormContext, useFormState, type ControllerProps, type FieldPath, type FieldValues } from "react-hook-form";
+
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> = {
+    name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
+
+const FormField = <TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>({ ...props }: ControllerProps<TFieldValues, TName>) => {
+    return (
+        <FormFieldContext.Provider value={{ name: props.name }}>
+            <Controller {...props} />
+        </FormFieldContext.Provider>
+    );
+};
+
+const useFormField = () => {
+    const fieldContext = React.useContext(FormFieldContext);
+    const itemContext = React.useContext(FormItemContext);
+    const { getFieldState } = useFormContext();
+    const formState = useFormState({ name: fieldContext.name });
+    const fieldState = getFieldState(fieldContext.name, formState);
+
+    if (!fieldContext) {
+        throw new Error("useFormField should be used within <FormField>");
+    }
+
+    const { id } = itemContext;
+
+    return {
+        id,
+        name: fieldContext.name,
+        formItemId: `${id}-form-item`,
+        formDescriptionId: `${id}-form-item-description`,
+        formMessageId: `${id}-form-item-message`,
+        ...fieldState,
+    };
+};
+
+type FormItemContextValue = {
+    id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+    const id = React.useId();
+
+    return (
+        <FormItemContext.Provider value={{ id }}>
+            <div
+                data-slot="form-item"
+                className={cn("grid gap-2", className)}
+                {...props}
+            />
+        </FormItemContext.Provider>
+    );
+}
+
+function FormLabel({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+    const { error, formItemId } = useFormField();
+
+    return (
+        <Label
+            data-slot="form-label"
+            data-error={!!error}
+            className={cn("data-[error=true]:text-destructive", className)}
+            htmlFor={formItemId}
+            {...props}
+        />
+    );
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+    const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
+
+    return (
+        <Slot
+            data-slot="form-control"
+            id={formItemId}
+            aria-describedby={!error ? `${formDescriptionId}` : `${formDescriptionId} ${formMessageId}`}
+            aria-invalid={!!error}
+            {...props}
+        />
+    );
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+    const { formDescriptionId } = useFormField();
+
+    return (
+        <p
+            data-slot="form-description"
+            id={formDescriptionId}
+            className={cn("text-muted-foreground text-sm", className)}
+            {...props}
+        />
+    );
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+    const { error, formMessageId } = useFormField();
+    const body = error ? String(error?.message ?? "") : props.children;
+
+    if (!body) {
+        return null;
+    }
+
+    return (
+        <p
+            data-slot="form-message"
+            id={formMessageId}
+            className={cn("text-destructive text-sm", className)}
+            {...props}>
+            {body}
+        </p>
+    );
+}
+
+export { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage, useFormField };

--- a/components/ui/icons.tsx
+++ b/components/ui/icons.tsx
@@ -1,0 +1,13 @@
+import { type LucideIcon, HandCoinsIcon } from "lucide-react";
+import type React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const HandCoinsFlippedIcon = ({ className, ...props }: React.ComponentProps<LucideIcon>) => (
+    <HandCoinsIcon
+        className={cn("scale-x-[-1]", className)}
+        {...props}
+    />
+);
+
+export type CustomLucideIcon = typeof HandCoinsFlippedIcon;

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+    return (
+        <input
+            type={type}
+            data-slot="input"
+            className={cn(
+                "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+                "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+                "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+export { Input };

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import * as LabelPrimitive from "@radix-ui/react-label";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+    return (
+        <LabelPrimitive.Root
+            data-slot="label"
+            className={cn(
+                "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+export { Label };

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+    return (
+        <PopoverPrimitive.Root
+            data-slot="popover"
+            {...props}
+        />
+    );
+}
+
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+    return (
+        <PopoverPrimitive.Trigger
+            data-slot="popover-trigger"
+            {...props}
+        />
+    );
+}
+
+function PopoverContent({ className, align = "center", sideOffset = 4, ...props }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+    return (
+        <PopoverPrimitive.Portal>
+            <PopoverPrimitive.Content
+                data-slot="popover-content"
+                align={align}
+                sideOffset={sideOffset}
+                className={cn(
+                    "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+                    className,
+                )}
+                {...props}
+            />
+        </PopoverPrimitive.Portal>
+    );
+}
+
+function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+    return (
+        <PopoverPrimitive.Anchor
+            data-slot="popover-anchor"
+            {...props}
+        />
+    );
+}
+
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, ToasterProps } from "sonner";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+    const { theme = "system" } = useTheme();
+
+    return (
+        <Sonner
+            theme={theme as ToasterProps["theme"]}
+            className="toaster group"
+            style={
+                {
+                    "--normal-bg": "var(--popover)",
+                    "--normal-text": "var(--popover-foreground)",
+                    "--normal-border": "var(--border)",
+                } as React.CSSProperties
+            }
+            {...props}
+        />
+    );
+};
+
+export { Toaster };

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+    return (
+        <textarea
+            data-slot="textarea"
+            className={cn(
+                "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+export { Textarea };

--- a/components/ui/toggle-group.tsx
+++ b/components/ui/toggle-group.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import { type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { toggleVariants } from "@/components/ui/toggle";
+import { cn } from "@/lib/utils";
+
+const ToggleGroupContext = React.createContext<VariantProps<typeof toggleVariants>>({
+    size: "default",
+    variant: "default",
+});
+
+function ToggleGroup({ className, variant, size, children, ...props }: React.ComponentProps<typeof ToggleGroupPrimitive.Root> & VariantProps<typeof toggleVariants>) {
+    return (
+        <ToggleGroupPrimitive.Root
+            data-slot="toggle-group"
+            data-variant={variant}
+            data-size={size}
+            className={cn("group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs", className)}
+            {...props}>
+            <ToggleGroupContext.Provider value={{ variant, size }}>{children}</ToggleGroupContext.Provider>
+        </ToggleGroupPrimitive.Root>
+    );
+}
+
+function ToggleGroupItem({ className, children, variant, size, ...props }: React.ComponentProps<typeof ToggleGroupPrimitive.Item> & VariantProps<typeof toggleVariants>) {
+    const context = React.useContext(ToggleGroupContext);
+
+    return (
+        <ToggleGroupPrimitive.Item
+            data-slot="toggle-group-item"
+            data-variant={context.variant || variant}
+            data-size={context.size || size}
+            className={cn(
+                toggleVariants({
+                    variant: context.variant || variant,
+                    size: context.size || size,
+                }),
+                "min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l",
+                className,
+            )}
+            {...props}>
+            {children}
+        </ToggleGroupPrimitive.Item>
+    );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const toggleVariants = cva(
+    "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+    {
+        variants: {
+            variant: {
+                default: "bg-transparent",
+                outline: "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+            },
+            size: {
+                default: "h-9 px-2 min-w-9",
+                sm: "h-8 px-1.5 min-w-8",
+                lg: "h-10 px-2.5 min-w-10",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+            size: "default",
+        },
+    },
+);
+
+function Toggle({ className, variant, size, ...props }: React.ComponentProps<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>) {
+    return (
+        <TogglePrimitive.Root
+            data-slot="toggle"
+            className={cn(toggleVariants({ variant, size, className }))}
+            {...props}
+        />
+    );
+}
+
+export { Toggle, toggleVariants };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,11 +12,11 @@ export const formatCurrency = (currency: number) =>
         signDisplay: "always",
     }).format(currency);
 
-export const formatDate = (date: Date) => {
+export const formatDate = (date: Date, dynamic: boolean = true) => {
     const isCurrentYear = date.getFullYear() === new Date().getFullYear();
     return date.toLocaleDateString("it-IT", {
         day: "numeric",
-        month: isCurrentYear ? "long" : "short",
-        year: isCurrentYear ? undefined : "numeric",
+        month: dynamic && isCurrentYear ? "long" : "short",
+        year: dynamic && isCurrentYear ? undefined : "numeric",
     });
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,12 +5,16 @@ export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }
 
-export const formatCurrency = (currency: number) =>
-    new Intl.NumberFormat("it-IT", {
+export const formatCurrency = (currency: number, displayCurrencySign: boolean = true, displayCurrencySymbol: boolean = true) => {
+    const formatted = new Intl.NumberFormat("it-IT", {
         style: "currency",
         currency: "EUR",
-        signDisplay: "always",
+        signDisplay: displayCurrencySign ? "always" : "never",
     }).format(currency);
+
+    if (displayCurrencySymbol) return formatted;
+    return formatted.substring(0, formatted.length - 2);
+};
 
 export const formatDate = (date: Date, dynamic: boolean = true) => {
     const isCurrentYear = date.getFullYear() === new Date().getFullYear();

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,4 @@
+import type { ExpenseOptionType } from "@/types/expenses";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
@@ -23,4 +24,16 @@ export const formatDate = (date: Date, dynamic: boolean = true) => {
         month: dynamic && isCurrentYear ? "long" : "short",
         year: dynamic && isCurrentYear ? undefined : "numeric",
     });
+};
+
+export const formatExpense = (expense: ExpenseOptionType) => {
+    const formatMap: { [key in ExpenseOptionType]: string } = {
+        expense: "Spesa aggiunta",
+        earning: "Entrata aggiunta",
+        borrowFulfill: "Debito aggiunto",
+        borrowPending: "Debito aggiunto",
+        lendFulfill: "Prestito aggiunto",
+        lendPending: "Prestito aggiunto",
+    };
+    return formatMap[expense];
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-day-picker": "^9.8.1",
         "react-dom": "19.1.1",
         "react-hook-form": "^7.62.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-safe-area": "^1.1.0",
         "zod": "^4.0.17"
@@ -6956,6 +6957,16 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-toggle": "^1.1.9",
+        "@radix-ui/react-toggle-group": "^1.1.10",
         "babel-plugin-react-compiler": "^19.1.0-rc.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1639,6 +1641,60 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.9.tgz",
+      "integrity": "sha512-ZoFkBBz9zv9GWer7wIjvdRxmh2wyc2oKWw6C6CseWd6/yq1DK/l5lJ+wnsmFwJZbBYqr02mrf8A2q/CVCuM3ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.10.tgz",
+      "integrity": "sha512-kiU694Km3WFLTC75DdqgM/3Jauf3rD9wxeS9XtyWFKsBUeZA337lC+6uUazT7I1DhanZ5gyD5Stf8uf2dbQxOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-toggle": "1.1.9",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "speezy",
       "version": "v0.0.1-alpha.2",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.1",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
         "babel-plugin-react-compiler": "^19.1.0-rc.2",
         "class-variance-authority": "^0.7.1",
@@ -22,9 +25,12 @@
         "next-themes": "^0.4.6",
         "postgres": "^3.4.7",
         "react": "19.1.1",
+        "react-day-picker": "^9.8.1",
         "react-dom": "19.1.1",
+        "react-hook-form": "^7.62.0",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss-safe-area": "^1.1.0"
+        "tailwindcss-safe-area": "^1.1.0",
+        "zod": "^4.0.17"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -127,6 +133,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.5",
@@ -339,6 +351,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1367,6 +1391,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-menu": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.15.tgz",
@@ -1389,6 +1436,43 @@
         "@radix-ui/react-roving-focus": "1.1.10",
         "@radix-ui/react-slot": "1.2.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.14.tgz",
+      "integrity": "sha512-ODz16+1iIbGUfFEfKx2HTPKizg2MN39uIOV8MXeHnmdd3i/N9Wt7vU46wbHsqA0xoaQyXVcs0KIlBdOA2Y95bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
       },
@@ -1716,6 +1800,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -3050,6 +3140,22 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -6276,6 +6382,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-day-picker": {
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.8.1.tgz",
+      "integrity": "sha512-kMcLrp3PfN/asVJayVv82IjF3iLOOxuH5TNFWezX6lS/T8iVRFPTETpHl3TUSTH99IDMZLubdNPJr++rQctkEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "^4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
@@ -6286,6 +6413,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {
@@ -7497,6 +7640,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
+      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-toggle": "^1.1.9",
+    "@radix-ui/react-toggle-group": "^1.1.10",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-day-picker": "^9.8.1",
     "react-dom": "19.1.1",
     "react-hook-form": "^7.62.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-safe-area": "^1.1.0",
     "zod": "^4.0.17"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
+    "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "class-variance-authority": "^0.7.1",
@@ -24,9 +27,12 @@
     "next-themes": "^0.4.6",
     "postgres": "^3.4.7",
     "react": "19.1.1",
+    "react-day-picker": "^9.8.1",
     "react-dom": "19.1.1",
+    "react-hook-form": "^7.62.0",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-safe-area": "^1.1.0"
+    "tailwindcss-safe-area": "^1.1.0",
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/providers/page-provider.tsx
+++ b/providers/page-provider.tsx
@@ -1,8 +1,9 @@
+import type React from "react";
+
 import Header from "@/components/header";
 import Navigation from "@/components/navigation";
 import { cn } from "@/lib/utils";
 import { AuthProvider } from "@/providers/auth-provider";
-import type React from "react";
 
 type PageProviderProps = React.ComponentProps<"section"> & { path: string };
 

--- a/types/expenses.ts
+++ b/types/expenses.ts
@@ -1,0 +1,12 @@
+import type { LucideIcon } from "lucide-react";
+
+import type { CustomLucideIcon } from "@/components/ui/icons";
+
+export const expenseOptionTypes = ["expense", "earning", "lent", "borrowed"] as const;
+
+export type ExpenseOptionType = {
+    type: (typeof expenseOptionTypes)[number];
+    name: string;
+    description: string;
+    Icon: LucideIcon | CustomLucideIcon;
+};

--- a/types/expenses.ts
+++ b/types/expenses.ts
@@ -2,7 +2,7 @@ import type { LucideIcon } from "lucide-react";
 
 import type { CustomLucideIcon } from "@/components/ui/icons";
 
-export const expenseOptionTypes = ["expense", "earning", "lent", "borrowed"] as const;
+export const expenseOptionTypes = ["expense", "earning", "lendPending", "borrowPending", "lendFulfill", "borrowFulfill"] as const;
 
 export type ExpenseOptionType = {
     type: (typeof expenseOptionTypes)[number];

--- a/types/expenses.ts
+++ b/types/expenses.ts
@@ -4,8 +4,10 @@ import type { CustomLucideIcon } from "@/components/ui/icons";
 
 export const expenseOptionTypes = ["expense", "earning", "lendPending", "borrowPending", "lendFulfill", "borrowFulfill"] as const;
 
-export type ExpenseOptionType = {
-    type: (typeof expenseOptionTypes)[number];
+export type ExpenseOptionType = (typeof expenseOptionTypes)[number];
+
+export type ExpenseOption = {
+    type: ExpenseOptionType;
     name: string;
     description: string;
     Icon: LucideIcon | CustomLucideIcon;


### PR DESCRIPTION
This PR introduces a full-featured transactionform, including input fields, validation. Four type of transactions can be added through this form:

- `expense`: money spent
- `earning`: money earned
- `lend`: mony have been lent to someone. Someone has to refund.
- `borrow`: money have been borrowed from someone. Someone needs to be refunded.

🚀 Features
- Added form skeleton with:
  - Date picker (formatted to ISO date string)
  - Amount input
  - Description textarea (with trimming + character limit)
  - Expense type toggle group
- Added expense variations (fulfilled and pending) with corresponding options
- Added form reset after submit
- Added confirmation toast after successful submission

🎨 Styling & UX
- Adjusted input sizes (date + amount)
- Updated submit button sizing
- Enforced character limit on description field
- Prevented unselecting expense type

🛠 Refactors
- Cleaned up imports and prop definitions
- Optimized onChange handlers
- Renamed expense types for clarity
- Simplified submit logs and removed unnecessary console logs

🐛 Fixes
- Fixed description unselect bug

📚 Docs
- Updated README.md with latest changes