### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     name: Test
+    permissions: {}
     uses: ./.github/workflows/test.yml
 
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/m-calabresi/speezy/security/code-scanning/4](https://github.com/m-calabresi/speezy/security/code-scanning/4)

To fix the issue, you should explicitly set a `permissions` block for the `test` job in the `.github/workflows/release.yml` file. The safest minimal configuration is `permissions: {}`, which disables all GITHUB_TOKEN permissions for the job. If your test workflow needs minimal read-only access (e.g., to access repository contents), set `contents: read`; otherwise, leaving it empty will ensure that the job adheres to the principle of least privilege.

You only need to add this block under the `test` job configuration, specifically after line 10 (the `name: Test` line). No additional imports, methods, or configuration are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
